### PR TITLE
Add TheAgentCompany benchmark (real-world professional tasks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,8 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **Verified-high (deep-research, 3/3 votes):** Verifier's Law, the `verifiers` library, EvalGen, Inspect AI, promptfoo, the ABC benchmark-rigor paper, plus lm-eval-harness, Autoevals, agentevals, AI Agents That Matter.
 - **Flagged caveats:** the MT-Bench 10/25 bias numbers are *hedged by their own authors*; Lee's "Agent Runtime" post URL and the WebArena/OSWorld/Terminal-Bench/Cybench links still need verification; the Kanav Garg talk is cited via a conference summary (no canonical primary URL yet).
 
+- **[TheAgentCompany](https://arxiv.org/abs/2412.14161)** — Xu et al. (CMU) — 175 consequential real-world professional tasks in a self-hosted company sandbox (GitLab, Plane, RocketChat, wiki) with simulated coworkers and checkpoint-based partial scoring; best agents fully complete ~24%. 🆕
+
 ## Deep notes
 
 This repo ships **146 deep reading notes** in [`notes/`](notes/) — structured summaries with key points, **verbatim quotes**, and themes, for the highest-signal sources:


### PR DESCRIPTION
Noticed the list is heavy on coding (SWE-bench) and web (WebArena) benchmarks but doesn't have anything covering the "can an agent do an actual office job end-to-end" angle. TheAgentCompany (CMU, NeurIPS-adjacent, arXiv 2412.14161) fills that gap nicely.

It's a fully self-hostable sandbox that mimics a small software company — GitLab, a Plane issue tracker, RocketChat, an internal wiki — with 175 tasks spanning SWE, PM, data science, HR and admin work, plus simulated coworkers you have to message to get unblocked. Checkpoint-based partial scoring rather than all-or-nothing, which I find more honest than most agent benchmarks. The headline result (best frontier agent fully completing ~24% of tasks at the time of the paper) is a useful reality check.

Code and task data are Apache-2.0 on GitHub and the leaderboard is public, so it's reproducible. Added one entry under the benchmarks section; happy to move it if it fits better elsewhere.