### PR TITLE
Add "The Complete Guide to LLM Evaluation in 2026" under Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,8 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **Verified-high (deep-research, 3/3 votes):** Verifier's Law, the `verifiers` library, EvalGen, Inspect AI, promptfoo, the ABC benchmark-rigor paper, plus lm-eval-harness, Autoevals, agentevals, AI Agents That Matter.
 - **Flagged caveats:** the MT-Bench 10/25 bias numbers are *hedged by their own authors*; Lee's "Agent Runtime" post URL and the WebArena/OSWorld/Terminal-Bench/Cybench links still need verification; the Kanav Garg talk is cited via a conference summary (no canonical primary URL yet).
 
+- **[The Complete Guide to LLM Evaluation in 2026](https://datadriftdaily.com/complete-guide-llm-evaluation-2026)** — Priya Nadkarni — A beginner-friendly walkthrough of LLM-as-a-judge, RAG metrics, hallucination detection, and how to pick an eval framework. 🆕
+
 ## Deep notes
 
 This repo ships **146 deep reading notes** in [`notes/`](notes/) — structured summaries with key points, **verbatim quotes**, and themes, for the highest-signal sources:


### PR DESCRIPTION
Hi team! Love what you're building here — this list is a fantastic resource and I reference it all the time.

I just published a comprehensive guide, "The Complete Guide to LLM Evaluation in 2026," that walks readers through everything from the basics of LLM-as-a-judge to RAG metrics, hallucination detection, and choosing an eval framework. It's beginner-friendly and covers all the major concepts in one place, so I think it'd be a great fit for the Guides section and a helpful starting point for newcomers.

Added one entry to the README under Guides. Happy to tweak the wording or placement to match your style — just let me know. Thanks for considering!