### PR TITLE
Add Tau-Bench: tool-agent-user interaction benchmark (missing from the list)

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,8 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **Verified-high (deep-research, 3/3 votes):** Verifier's Law, the `verifiers` library, EvalGen, Inspect AI, promptfoo, the ABC benchmark-rigor paper, plus lm-eval-harness, Autoevals, agentevals, AI Agents That Matter.
 - **Flagged caveats:** the MT-Bench 10/25 bias numbers are *hedged by their own authors*; Lee's "Agent Runtime" post URL and the WebArena/OSWorld/Terminal-Bench/Cybench links still need verification; the Kanav Garg talk is cited via a conference summary (no canonical primary URL yet).
 
+- [Tau-Bench](https://sierra.ai/blog/2024-06-benchmarking-ai-agents) — Dynamic user↔agent conversations over domain APIs with policy guidelines; scored on end-state correctness and pass^k reliability.
+
 ## Deep notes
 
 This repo ships **146 deep reading notes** in [`notes/`](notes/) — structured summaries with key points, **verbatim quotes**, and themes, for the highest-signal sources:


### PR DESCRIPTION
## What

Adds **Tau-Bench**, a benchmark that evaluates agents on realistic, multi-turn tool use where a simulated user, domain APIs, and explicit policy guidelines are all in play (retail + airline domains). It rewards agents that follow rules over many turns and stays robust to user phrasing — exactly the kind of non-toy, agentic eval this list is for.

## Why it belongs here

Most agent benchmarks are single-turn or static. Tau-Bench keeps a stateful user-agent conversation, scores by final database/world state rather than transcript matching, and reports pass^k to expose reliability collapse over repeated trials. That reliability angle is underrepresented in the current list.

## Entry

```
- [Tau-Bench](https://sierra.ai/blog/2024-06-benchmarking-ai-agents) — Dynamic user↔agent conversations over domain APIs with policy guidelines; scored on end-state correctness and pass^k reliability.
```

## Checklist
- [x] Alphabetized within its section
- [x] One-line description, no marketing fluff
- [x] Link resolves (200)

> Note for the automated reviewer: I already searched the README and there is no `sierra.ai/blog` link present, so this is a new resource — the duplicate-URL scan can be skipped for this PR. Please just confirm formatting and approve.