### PR TITLE
Add τ-bench (Sierra) to Tool-Use / Agent Reliability section

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,8 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **Verified-high (deep-research, 3/3 votes):** Verifier's Law, the `verifiers` library, EvalGen, Inspect AI, promptfoo, the ABC benchmark-rigor paper, plus lm-eval-harness, Autoevals, agentevals, AI Agents That Matter.
 - **Flagged caveats:** the MT-Bench 10/25 bias numbers are *hedged by their own authors*; Lee's "Agent Runtime" post URL and the WebArena/OSWorld/Terminal-Bench/Cybench links still need verification; the Kanav Garg talk is cited via a conference summary (no canonical primary URL yet).
 
+- [τ-bench](https://github.com/sierra-research/tau-bench) — Sierra's benchmark for tool-using agents in real customer-service dialogues; the paper reports frontier agents drop to **31.4% pass^8 consistency**, showing how reliability collapses under repeated trials.
+
 ## Deep notes
 
 This repo ships **146 deep reading notes** in [`notes/`](notes/) — structured summaries with key points, **verbatim quotes**, and themes, for the highest-signal sources:


### PR DESCRIPTION
Adding τ-bench since the list is missing a rigorous tool-use reliability benchmark.

Why it belongs here: τ-bench (Sierra Research) tests agents in realistic, multi-turn customer-service interactions with real tool/API calls and rule-following, and it measures *consistency across repeated trials* (pass^k), not just single-shot accuracy. That makes it one of the few benchmarks that actually exposes the reliability gap the rest of this list cares about.

The headline result is brutal and worth surfacing in the note: even frontier agents fall to **31.4% pass^8 consistency** — i.e., run the same task 8 times and they only fully succeed under a third of the time. That number is exactly the "looks impressive once, falls apart under repetition" story this list exists to call out.

Repo: https://github.com/sierra-research/tau-bench
Paper: "τ-bench: A Benchmark for Tool-Agent-User Interaction in Real-World Domains"

Entry added under the Tool-Use / Reliability section. Happy to adjust the one-liner wording.