### PR TITLE
Add τ²-bench (dual-control conversational agent benchmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,8 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **Verified-high (deep-research, 3/3 votes):** Verifier's Law, the `verifiers` library, EvalGen, Inspect AI, promptfoo, the ABC benchmark-rigor paper, plus lm-eval-harness, Autoevals, agentevals, AI Agents That Matter.
 - **Flagged caveats:** the MT-Bench 10/25 bias numbers are *hedged by their own authors*; Lee's "Agent Runtime" post URL and the WebArena/OSWorld/Terminal-Bench/Cybench links still need verification; the Kanav Garg talk is cited via a conference summary (no canonical primary URL yet).
 
+- [τ²-bench](https://github.com/sierra-research/tau2-bench) — Dual-control conversational-agent benchmark: both the agent and the simulated user can act on a shared state. Extends τ-bench with a telecom domain and a `pass^k` reliability metric for flaky-agent measurement. ([paper](https://arxiv.org/abs/2506.07982)) \`tool-use\` \`conversational\` \`reliability\
+
 ## Deep notes
 
 This repo ships **146 deep reading notes** in [`notes/`](notes/) — structured summaries with key points, **verbatim quotes**, and themes, for the highest-signal sources:


### PR DESCRIPTION
Proposing τ²-bench for the list. Short pitch on why it clears the bar:

- **What it is:** A benchmark for tool-using conversational agents in a *dual-control* environment — unlike most agent benchmarks, BOTH the agent and the simulated user can take actions that mutate a shared world state. This forces the agent to coordinate, instruct the user, and recover from user-side actions, which single-actor benchmarks (including the original τ-bench) cannot measure.
- **Why it's distinct from τ-bench:** New formalism (Dec-POMDP / dual control), new telecom domain plus reworked retail/airline, and it reports `pass^k` (reliability across k independent rollouts) rather than just pass@1 — directly targeting the "agents are flaky" failure mode this list cares about.
- **Real, high-signal, reproducible:** Open-source harness, public task suite, and a maintained leaderboard. From the Sierra team (same authors as τ-bench).
- **Links:** repo https://github.com/sierra-research/tau2-bench · paper https://arxiv.org/abs/2506.07982

I searched the README for "tau2" / "τ²" and found nothing — the existing τ-bench entry is a different benchmark. Suggested home: the tool-use / conversational agent benchmarks section, right after the τ-bench line so readers see the lineage.