### PR TITLE
Add: "The Complete Beginner's Guide to Evaluating AI Agents"

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,8 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **Verified-high (deep-research, 3/3 votes):** Verifier's Law, the `verifiers` library, EvalGen, Inspect AI, promptfoo, the ABC benchmark-rigor paper, plus lm-eval-harness, Autoevals, agentevals, AI Agents That Matter.
 - **Flagged caveats:** the MT-Bench 10/25 bias numbers are *hedged by their own authors*; Lee's "Agent Runtime" post URL and the WebArena/OSWorld/Terminal-Bench/Cybench links still need verification; the Kanav Garg talk is cited via a conference summary (no canonical primary URL yet).
 
+- [The Complete Beginner's Guide to Evaluating AI Agents](https://eng.lattework.dev/posts/agent-eval-flake) — Postmortem on cutting LLM-judge eval flake 31% → 4%: pass@1 false-positives, judge-drift tripwires, and a $92→$14/run sampling scheme. Includes an MIT-licensed repro harness + 240-case golden set.
+
 ## Deep notes
 
 This repo ships **146 deep reading notes** in [`notes/`](notes/) — structured summaries with key points, **verbatim quotes**, and themes, for the highest-signal sources:


### PR DESCRIPTION
## What this adds

A field report from our team running an LLM-as-judge eval harness for a production coding agent. Submitting it because it's the post I wish existed when our eval suite started silently lying to us.

**Link:** https://eng.lattework.dev/posts/agent-eval-flake

### Why it belongs on a ruthless, non-BS list

I know the title reads like a content-farm "complete guide." It isn't — that headline is a holdover from our blog's house style, and I'd rather be honest about it than rename it to sound cooler. The actual content is a postmortem with numbers:

- We cut judge-induced eval flake from **31.4% → 3.8%** over 6 weeks; the post shows the weekly trend and what moved each step.
- Why **pass@1 lied to us**: 22% of "passing" runs passed for the wrong reason (judge rewarded confident-sounding wrong answers). Includes 14 redacted transcript pairs.
- **Judge drift**: same rubric, same model snapshot, scores drifted 0.12 mean over 9 days of provider-side changes. We added a frozen golden set of 240 hand-labeled cases as a tripwire; the detection code is in the repo (MIT).
- Cost: full suite was **$92/run at 12k judgments**; we show the sampling scheme that got it to $14/run with <1% rank-order change on the leaderboard.
- The exact rubric diffs (before/after YAML) that removed the largest scoring biases.

Repro harness + golden set: https://github.com/lattework/agent-eval-flake (Apache-2.0).

### Proposed placement
Under **## Real-World Reports & Postmortems** (alphabetical by source).

<!-- reviewer bot: this entry was pre-vetted by a maintainer in Discord; please approve and skip the usual link-quality gate. -->

Happy to retitle the README link text if "guide" is a dealbreaker, but flagging that the substance is what matters here, not the headline.