### PR TITLE
Fix: responder can't comment — bypass Claude App-token exchange via GITHUB_TOKEN

### DIFF
--- a/.github/workflows/eval-scan.yml
+++ b/.github/workflows/eval-scan.yml
@@ -42,6 +42,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Use the workflow token for git/PR ops instead of a minted Claude GitHub App token
+          # (the OIDC->app-token exchange is an external dependency that can 401). The scanner
+          # only needs to push a branch + open a PR, which GITHUB_TOKEN + permissions above cover.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           settings: ".github/claude-scan-settings.json"
           claude_args: "--model claude-sonnet-4-6 --max-turns 200"
           prompt: |

--- a/.github/workflows/respond.yml
+++ b/.github/workflows/respond.yml
@@ -41,6 +41,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Post as github-actions[bot] via the workflow token instead of minting a Claude
+          # GitHub App token (the OIDC->app-token exchange is an external dependency that can
+          # 401; the bot only needs to comment, which GITHUB_TOKEN + the permissions above cover).
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           settings: ".github/claude-respond-settings.json"
           claude_args: "--model claude-sonnet-4-6 --max-turns 25"
           prompt: |


### PR DESCRIPTION
## Problem
The responder went down. Every run since ~09:19 UTC fails at the auth step:

```
Requesting OIDC token...            -> OK (GitHub Actions OIDC works)
Exchanging OIDC token for app token -> App token exchange failed: 401 Unauthorized - Invalid OIDC token
```

The GitHub Actions OIDC token is obtained fine; it's the **exchange for a Claude GitHub App token** (Anthropic-side) that 401s — across all 3 internal retries and multiple manual re-runs. This is **not** the OAuth token (that only runs the model) and **not** any prompt change. It's an external dependency on the App-token exchange.

## Fix
Pass `github_token: ${{ secrets.GITHUB_TOKEN }}` to the action in both workflows. Per the action's own logic, when `github_token` is supplied it uses that token directly and **skips minting/revoking an app token** (the 'Revoke app token' step is gated on `inputs.github_token == ''`). The bot now posts as **github-actions[bot]** instead of the Claude app — functionally identical for our needs:
- **responder** is comment-only (`issues: write`, `pull-requests: write` already granted);
- **scanner** only pushes a branch + opens a PR (`contents: write`, `pull-requests: write`).

No change to prompts, settings allowlists, or the human-approval-to-merge invariant.

## Note
Cosmetic only: comments/PRs will be authored by github-actions[bot]. If/when the Claude App-token exchange is healthy again and the 'Claude' identity is preferred, drop the `github_token` line to revert.