### PR TITLE
Add whatbroke to 5f (observability + eval platforms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **[Datadog LLM Observability](https://www.datadoghq.com/product/ai/llm-observability/)** — <https://www.datadoghq.com/product/ai/llm-observability/> — 🆕 evaluators + golden datasets + **LLM Experiments** + AI Agent Monitoring (Jun 2025).
 - **[Fiddler AI](https://www.fiddler.ai/)** — <https://www.fiddler.ai/> — 🆕 Trust Models (Safety/PII/Faithfulness) scoring in <100ms; Guardrails + agentic observability.
 - **[PromptLayer](https://www.promptlayer.com/)** — <https://www.promptlayer.com/> · **New Relic AI Monitoring** — <https://newrelic.com/platform/ai-monitoring> — lighter prompt-CMS / APM-native monitoring.
+- **[whatbroke](https://github.com/arthi-arumugam-git/whatbroke)** — <https://github.com/arthi-arumugam-git/whatbroke> · *tool* — OSS CLI that diffs two agent trace files (JSONL) before/after a model or prompt change: dropped tool calls, drifted args, reordering, cost/latency/outcome deltas; multi-sample flap rates demote baseline flakiness so only real regressions surface. Offline, deterministic, no judge or API keys; CI-gateable exit codes. 🆕
 
 ### 5g · Tracing standards
 - **[OpenInference](https://github.com/Arize-ai/openinference)** — Arize — <https://github.com/Arize-ai/openinference> — semantic conventions for agent traces (tool/args/observation/latency/cost).


### PR DESCRIPTION
One-line addition to 5f: whatbroke, an open-source CLI I built that diffs two agent trace files before/after a model or prompt swap. It reports dropped tool calls, drifted arguments, reordering, and cost/latency/outcome deltas, and uses multi-sample flap rates to demote behavior that was already flaky in the baseline.

Why it clears the bar: it answers a question the eval platforms in this section don't directly answer (what exactly changed between these two versions, at tool-call level) without a rubric or a judge. Deterministic and offline, so it slots in front of a full eval-suite run. MIT, TypeScript, on npm as whatbroke-cli.

Happy to move it to a different section if you think it fits better elsewhere.