### PR TITLE
Add FinMirror paired-world RAG evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **[RAGChecker](https://github.com/amazon-science/RAGChecker)** — Amazon Science — <https://github.com/amazon-science/RAGChecker> — 🆕 claim-level diagnosis separating retriever vs generator errors.
 - **[continuous-eval (Relari)](https://github.com/relari-ai/continuous-eval)** — <https://github.com/relari-ai/continuous-eval> — modular per-module metrics across retrieval/generation/tool-use.
 - **[Tonic Validate](https://github.com/TonicAI/tonic_validate)** — <https://github.com/TonicAI/tonic_validate> — RAG metrics as a GitHub Action for CI.
+- **[FinMirror](https://github.com/faceWang753/finmirror)** — Mingyang (Ethan) Wang — <https://github.com/faceWang753/finmirror> · *benchmark/tool* — 🆕 deterministic paired-world tests for financial RAG/agents across answers, citations, calculation provenance, confidence, and abstention; v0.1 is 126 synthetic cases, not a production-safety claim. ⚠️
 
 ### 5d · LLM-as-judge / reward / verifier libraries
 - **[verdict](https://github.com/haizelabs/verdict)** — Haize Labs — <https://github.com/haizelabs/verdict> — 🆕 declarative compound judges (debate/verification/aggregation, inference-time scaling); arXiv:2502.18018.


### PR DESCRIPTION
## Why it belongs

- Runnable benchmark, evaluator, synthetic data, tests, and a zero-key demo rather than a generic evaluation article.
- Tests whether a financial RAG system changes for the right evidence-dependent reason.
- Uses deterministic scoring for the v0.1 core rather than an LLM judge.

## Links

- Repository: https://github.com/faceWang753/finmirror
- Demo: https://facewang753.github.io/finmirror/
- Hugging Face dataset: https://huggingface.co/datasets/mingyang233/FinMirror

## Caveat

v0.1 contains 126 synthetic cases. It demonstrates the protocol and harness, not production reliability or results for a hosted model.

This PR makes one README-only change and follows the project’s requested entry format.