### PR TITLE
5c: add Verbatim Citation Gate (RAG / retrieval evaluation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **[continuous-eval (Relari)](https://github.com/relari-ai/continuous-eval)** — <https://github.com/relari-ai/continuous-eval> — modular per-module metrics across retrieval/generation/tool-use.
 - **[Tonic Validate](https://github.com/TonicAI/tonic_validate)** — <https://github.com/TonicAI/tonic_validate> — RAG metrics as a GitHub Action for CI.
 
+- **[Verbatim Citation Gate](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate)** — <https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate> — zero-token verbatim span check in front of a burden-of-proof judge, so fabricated quotes are rejected before any LLM call; framework-agnostic.
 ### 5d · LLM-as-judge / reward / verifier libraries
 - **[verdict](https://github.com/haizelabs/verdict)** — Haize Labs — <https://github.com/haizelabs/verdict> — 🆕 declarative compound judges (debate/verification/aggregation, inference-time scaling); arXiv:2502.18018.
 - **[RULER](https://github.com/OpenPipe/ART)** — OpenPipe (ART) — <https://github.com/OpenPipe/ART> (`art.openpipe.ai/fundamentals/ruler`) — 🆕 LLM-judge that ranks trajectories with no labels — judge-as-RL-reward. **(industry must-read)**


### PR DESCRIPTION
One entry at the end of **5c · RAG / retrieval evaluation**, in the section's `- **[Name](url)** — <url> — description` format.

**[Verbatim Citation Gate](https://github.com/Palo-Alto-AI-Research-Lab/verbatim-citation-gate)** — two stages. First a deterministic check with no model call: every quoted span must appear verbatim in the retrieved context, so an invented quote dies immediately and for free. Only survivors reach a burden-of-proof judge, which must affirmatively demonstrate support rather than merely fail to object.

**Why it is a distinct row next to the existing five:** TruLens, ARES, RAGChecker and continuous-eval all grade a corpus after the fact with a model in the loop. This one is designed to sit *inline* in the request path, and its first stage is string comparison — which makes the judge stage cheap enough to run on live traffic rather than on a sample. It is complementary to the tools already listed, not a replacement, and it does not ship its own metrics suite.

The burden-of-proof framing also connects to 5d: the judge is prompted to prove support, which inverts the usual failure mode where a judge waves through anything that looks plausible.

MIT, last push 2026-07-24, no hosted component. Checked 5c and 5d for a duplicate — nothing matching.

Honest caveat given this list's bar: the repo is early and has no independent adoption yet — no published third-party benchmark of the gate, and 0 stars. If 5c is reserved for tools with external validation, closing this is a fair call.