### PR TITLE
Add Open Multi-Agent evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 ### 5b · TypeScript/JS-native eval runners
 - **[evalite](https://github.com/mattpocock/evalite)** — Matt Pocock — <https://github.com/mattpocock/evalite> — 🆕 local-first eval runner on Vitest; `.eval.ts` files, web UI, cost-aware.
 - **[Mastra scorers](https://github.com/mastra-ai/mastra)** — <https://github.com/mastra-ai/mastra> (`mastra.ai/docs/evals/overview`) — 🆕 model-graded/rule/statistical scorers, live evals, CI, in the Mastra agent framework.
+- **[Open Multi-Agent evaluation](https://github.com/open-multi-agent/open-multi-agent)** — Open Multi-Agent — <https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/evaluation.md> · *tool/framework* — 🆕 TypeScript-native, versioned EvalSets with offline JSON/Markdown/JUnit reports, baseline regression gates for CI, and opt-in production sampling that scores settled runs asynchronously without changing their results.
 - **[Vercel agent-eval](https://github.com/vercel-labs/agent-eval)** — <https://github.com/vercel-labs/agent-eval> — 🆕 A/B-test coding agents (Claude Code, Codex, Cursor) on custom tasks; pass-rate dashboards.
 - **[Autoevals](https://github.com/braintrustdata/autoevals)** — Braintrust — <https://github.com/braintrustdata/autoevals> — OSS scorer library (Factuality, relevance, security…) across Py/JS/Go/Ruby.
 


### PR DESCRIPTION
## Summary

Add only the [Open Multi-Agent evaluation surface](https://github.com/open-multi-agent/open-multi-agent/blob/main/docs/evaluation.md) to **§5b · TypeScript/JS-native eval runners**.

## Why it clears the bar

This is a code-first TypeScript evaluation surface rather than a generic observability mention:

- versioned EvalSets and scorers;
- offline JSON, Markdown, and JUnit reports;
- threshold and baseline-regression gates with CI exit-code behavior; and
- opt-in production sampling that evaluates settled runs asynchronously and is isolated from the business result.

The public [evaluation implementation](https://github.com/open-multi-agent/open-multi-agent/tree/main/packages/core/src/eval) and focused tests such as [offline runner](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/core/tests/eval-runner.test.ts), [gates](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/core/tests/eval-gate.test.ts), and [online isolation](https://github.com/open-multi-agent/open-multi-agent/blob/main/packages/core/tests/eval-online.test.ts) show the work behind the one-line entry.

## Verification

- Checked the current README and open/closed issues and pull requests for the canonical repository URL and exact project name; no existing OMA submission was found.
- Confirmed the repository and evaluation documentation links return HTTP 200.
- Ran `git diff --check`.

## Disclosure

I am a maintainer of Open Multi-Agent.
