### PR TITLE
Add RepoTrials to eval frameworks and harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **[UpTrain](https://github.com/uptrain-ai/uptrain)** — <https://github.com/uptrain-ai/uptrain> — 20+ preconfigured checks + root-cause analysis on failures.
 - **[HF `evaluate`](https://github.com/huggingface/evaluate)** — <https://github.com/huggingface/evaluate> — classic metrics library, ⚠️ maintenance mode (use lighteval for LLMs).
 - **[Harbor](https://github.com/harbor-framework/harbor)** — harbor-framework (Laude Institute / Stanford) — <https://github.com/harbor-framework/harbor> — 🆕 framework for running agent evals + creating/using RL environments; powers Terminal-Bench 2.0. ~2.7k★. ⚠️ name overloaded (cf. `av/harbor` local-LLM toolkit).
+- **[RepoTrials](https://github.com/PozziTiv4ik/Repo-Trials)** — PozziTiv4ik — <https://github.com/PozziTiv4ik/Repo-Trials> · *tool/framework* — 🆕 Local-first CLI that mines a codebase’s Git history into sealed coding-agent tasks, validates BASE/RED/GOLD test transitions, and compares repeated agent trials with hidden behavioral grading; exports Harbor tasks.
 
 ### 5b · TypeScript/JS-native eval runners
 - **[evalite](https://github.com/mattpocock/evalite)** — Matt Pocock — <https://github.com/mattpocock/evalite> — 🆕 local-first eval runner on Vitest; `.eval.ts` files, web UI, cost-aware.


### PR DESCRIPTION
## What changed

Adds RepoTrials to **§5a · Eval frameworks & harnesses (code-first test-runners)**.

## Why it belongs

RepoTrials is an Apache-2.0, local-first Python CLI for building repository-specific coding-agent evaluations from real fixes already present in Git history. It reconstructs the pre-fix state, seals task material, validates BASE/RED/GOLD test transitions, runs repeated agent trials, and grades behavior with hidden tests rather than gold-diff similarity. It can also export tasks for Harbor.

The specific gap it addresses is task creation for a team's own repository: instead of relying only on a fixed public corpus or requiring every task to be authored by hand, it turns reviewed historical fixes into reproducible private evaluations.

- First public release: https://github.com/PozziTiv4ik/Repo-Trials/releases/tag/v0.1.0
- No-key runnable demo: https://github.com/PozziTiv4ik/Repo-Trials#try-it-in-60-seconds

## Disclosure and maturity

I am submitting this on behalf of the project's maintainer and owner, @PozziTiv4ik. Version v0.1.0 is the first public release. The repository has a working demo and automated tests, but I am not claiming independent adoption or production maturity.

## Validation

- Changed only `README.md`, with one added entry.
- `git diff --check` passes.
- Verified the canonical repository URL returns HTTP 200.
- Checked the current open pull requests for an existing RepoTrials submission; none was present.