### PR TITLE
Add MCP Lens Schema Audit to agent-specific evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **[First-Principles Eval](https://leehanchung.github.io/blogs/2024/05/22/first-principles-eval/)** — Han-Chung Lee — <https://leehanchung.github.io/blogs/2024/05/22/first-principles-eval/> · *blog*.
 - **[SWE-bench grading harness](https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/grading.py)** — <https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/grading.py> · *tool/repo* — FAIL_TO_PASS / PASS_TO_PASS as a verifiable reward. (SWE-agent ACI: <https://swe-agent.com/0.7/background/aci/>)
 - **[human-eval (pass@k estimator)](https://github.com/openai/human-eval/blob/master/human_eval/evaluation.py)** — OpenAI — <https://github.com/openai/human-eval/blob/master/human_eval/evaluation.py> · *tool/repo*.
+- **[MCP Lens Schema Audit](https://github.com/labmimors/dsh-mcp-lens#keep-schema-drift-out-of-ci)** — labmimors — <https://github.com/labmimors/dsh-mcp-lens> · *GitHub Action/tool* — Deterministic Node 24 check that measures model-facing tool count and Tool Schema JSON UTF-8 bytes from a checked-in MCP payload, then enforces optional CI budgets without a model call or API key. 🆕
 - **More agent benchmarks to add** *(named in the brief; URLs not yet verified in this corpus — verify before use):* WebArena, OSWorld, Terminal-Bench, Cybench.
 
 - **[WebArena: A Realistic Web Environment for Building Autonomous Agents](https://arxiv.org/abs/2307.13854)** — Zhou et al. (CMU) — <https://arxiv.org/abs/2307.13854> · *benchmark* — Self-hostable sandboxed websites (e-commerce/forum/GitLab/CMS/maps) with execution-based functional-correctness graders; 812 tasks. The canonical web-agent world-state benchmark named in the brief — now URL-verified.
@@ -570,7 +571,6 @@ PRs welcome. Keep the bar high: **show your work** (real data/code/war-stories b
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](LICENSE)
 
 To the extent possible under law, [BenchFlow](https://benchflow.ai) and contributors have waived all copyright and related rights to this work (CC0 1.0). The linked resources remain under their respective licenses.
-
 
 
 


### PR DESCRIPTION
## Why this belongs

This adds one deterministic GitHub Action to **§9 · Agent-specific evaluation**. Given a checked-in model-facing MCP tool payload, it reports tool count and Tool Schema JSON UTF-8 bytes and can fail CI on explicit `max-tools` or `max-schema-bytes` thresholds.

This is deliberately a component-level check for the tool surface presented to an agent, not an end-to-end task or agent-quality evaluation.

## Show your work

- The [Action contract](https://github.com/labmimors/dsh-mcp-lens/blob/main/action.yml) fixes the Node 24 runtime, inputs, outputs, and budget behavior.
- The [implementation](https://github.com/labmimors/dsh-mcp-lens/blob/main/action/index.js) uses no model call, API key, or network request.
- The public [Action tests](https://github.com/labmimors/dsh-mcp-lens/blob/main/tests/action.spec.ts) cover accepted payload shapes, numeric outputs, threshold failures, and Step Summary behavior. I reproduced all 9 tests in a fresh checkout before opening this PR.

## Verification

- Confirmed both canonical links return HTTP 200.
- Checked this repository plus open/closed GitHub issues and PRs for `dsh-mcp-lens`, `MCP Lens`, and the canonical repository URL; no existing submission was found.
- Ran `git diff --check`; the content change is one README entry.

## Disclosure

I am the maintainer of `labmimors/dsh-mcp-lens`.
