### PR TITLE
5a: add Gauntlet — merge-blocking eval gates for a deployed feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **[UpTrain](https://github.com/uptrain-ai/uptrain)** — <https://github.com/uptrain-ai/uptrain> — 20+ preconfigured checks + root-cause analysis on failures.
 - **[HF `evaluate`](https://github.com/huggingface/evaluate)** — <https://github.com/huggingface/evaluate> — classic metrics library, ⚠️ maintenance mode (use lighteval for LLMs).
 - **[Harbor](https://github.com/harbor-framework/harbor)** — harbor-framework (Laude Institute / Stanford) — <https://github.com/harbor-framework/harbor> — 🆕 framework for running agent evals + creating/using RL environments; powers Terminal-Bench 2.0. ~2.7k★. ⚠️ name overloaded (cf. `av/harbor` local-LLM toolkit).
+- **[Gauntlet](https://github.com/ChelseaKR/gauntlet)** — <https://github.com/ChelseaKR/gauntlet> · <https://chelseakr.github.io/gauntlet/> — 🆕 merge-blocking eval gates for a *deployed feature* rather than a model: YAML suites run against any HTTP endpoint or Python callable, fail the build on a miss, and emit both a diffable JSON pack and a reviewer document cross-referenced to California's published GenAI risk framework. Ships a composite GitHub Action. ⚠️ v0.1.0, single maintainer.
 
 ### 5b · TypeScript/JS-native eval runners
 - **[evalite](https://github.com/mattpocock/evalite)** — Matt Pocock — <https://github.com/mattpocock/evalite> — 🆕 local-first eval runner on Vitest; `.eval.ts` files, web UI, cost-aware.


### PR DESCRIPTION
Adds one entry to **5a · Eval frameworks & harnesses**.

<!-- github-markdown-guard: allow-next-code-block -->
```
- **[Gauntlet](https://github.com/ChelseaKR/gauntlet)** — <https://github.com/ChelseaKR/gauntlet> · <https://chelseakr.github.io/gauntlet/> — 🆕 merge-blocking eval gates for a *deployed feature* rather than a model: YAML suites run against any HTTP endpoint or Python callable, fail the build on a miss, and emit both a diffable JSON pack and a reviewer document cross-referenced to California's published GenAI risk framework. Ships a composite GitHub Action. ⚠️ v0.1.0, single maintainer.
```

## Why it clears the bar

The section already covers code-first runners well, so the case is not "another harness." It is the part that comes after a run finishes.

- **The unit under test is the feature, not the model.** Gates evaluate prompts, retrieval, guardrails and routing as deployed. Most of 5a scores a model against a dataset; this scores a system in its context, and it is vendor-neutral by construction.
- **The output is designed for a reviewer, not just a scoreboard.** Every run emits two artifacts from one source: a versioned JSON pack a machine can diff across commits, and a document mapping what the gates found to a named public risk framework. I did not find another entry in this list that treats the governance artifact as a build output.
- **Failure is the point.** It is a merge gate first and a report second, which is what keeps red-team findings regression-tested after the exercise ends rather than living in a PDF.

Verified at the tagged release: ruff, mypy strict, 405 tests, 99.94% coverage.

## Honest caveats

Per the "verify the URL" and "note caveats" guidance, stating these up front:

- **Early.** v0.1.0 is the first tagged release, cut today. The entry points at the repo and the docs site, both live.
- **Not yet installable from PyPI.** The package is `gauntlet-evals`; publishing runs through Trusted Publishing and is not live yet, so the entry deliberately does not advertise an install command. Worth flagging for anyone checking: the unrelated `gauntlet` name on PyPI is an abandoned third-party stub, not this project.
- **Single maintainer, low star count.** I wrote it. Saying so plainly since this is a self-submission.
- **Scope is deliberately narrow.** It does not benchmark foundation models and has no opinion about which one you use.

The README is explicit that the framework alignment is "aligned to," never "approved by," and that the State of California has not reviewed or endorsed it.

Happy to move it to a different section, tighten the annotation, or have it declined as too early. No hard feelings if the answer is "come back when it has users."
