### PR TITLE
Add Proofline to agent-specific evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **[First-Principles Eval](https://leehanchung.github.io/blogs/2024/05/22/first-principles-eval/)** — Han-Chung Lee — <https://leehanchung.github.io/blogs/2024/05/22/first-principles-eval/> · *blog*.
 - **[SWE-bench grading harness](https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/grading.py)** — <https://github.com/SWE-bench/SWE-bench/blob/main/swebench/harness/grading.py> · *tool/repo* — FAIL_TO_PASS / PASS_TO_PASS as a verifiable reward. (SWE-agent ACI: <https://swe-agent.com/0.7/background/aci/>)
 - **[human-eval (pass@k estimator)](https://github.com/openai/human-eval/blob/master/human_eval/evaluation.py)** — OpenAI — <https://github.com/openai/human-eval/blob/master/human_eval/evaluation.py> · *tool/repo*.
+- **[Proofline](https://github.com/ceodaradigu/proofline-agent)** — RELAUNCH DEPT — <https://github.com/ceodaradigu/proofline-agent> · *tool/repo* — 🆕 evaluates agent work against explicit requirements and fresh evidence with deterministic `NEEDS_EVIDENCE` / `CONFLICT` / `APPROVAL_REQUIRED` / `READY` outcomes and hash-addressed proof packets; runnable synthetic fixtures plus a public Google ADK / Cloud Run demo. ⚠️ New maintainer-submitted project; evaluates completion evidence, not model quality, and claims no independent adoption.
 - **More agent benchmarks to add** *(named in the brief; URLs not yet verified in this corpus — verify before use):* WebArena, OSWorld, Terminal-Bench, Cybench.
 
 - **[WebArena: A Realistic Web Environment for Building Autonomous Agents](https://arxiv.org/abs/2307.13854)** — Zhou et al. (CMU) — <https://arxiv.org/abs/2307.13854> · *benchmark* — Self-hostable sandboxed websites (e-commerce/forum/GitLab/CMS/maps) with execution-based functional-correctness graders; 812 tasks. The canonical web-agent world-state benchmark named in the brief — now URL-verified.
@@ -570,7 +571,6 @@ PRs welcome. Keep the bar high: **show your work** (real data/code/war-stories b
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](LICENSE)
 
 To the extent possible under law, [BenchFlow](https://benchflow.ai) and contributors have waived all copyright and related rights to this work (CC0 1.0). The linked resources remain under their respective licenses.
-
 
 
 


### PR DESCRIPTION
## What changed

Adds one annotated Proofline entry to §9, Agent-specific evaluation.

## Why it belongs

Proofline evaluates whether agent work is actually supported by explicit requirements and fresh evidence. Its deterministic gate produces `NEEDS_EVIDENCE`, `CONFLICT`, `APPROVAL_REQUIRED`, or `READY`, then emits a hash-addressed proof packet. The repository includes runnable synthetic fixtures and a public Google ADK / Cloud Run demo.

This is deliberately not presented as a model-quality evaluator. Its scope is task-completion evidence and the approval boundary before an external action.

## Disclosure and maturity

This is a self-submission from the RELAUNCH DEPT maintainer. The project is new; the entry explicitly states that there is no independent adoption claim. This PR was prepared with OpenAI Codex assistance under RELAUNCH DEPT's accountable review workflow.

## Verification

- Checked the README, repository code search, and all-state pull requests for `Proofline` and the canonical repository URL; no duplicate was found.
- Verified the canonical repository is public, active, unarchived, and MIT-licensed.
- Read `CONTRIBUTING.md` and matched its one-line why, URL, section, evidence, and caveat requirements.
- `git diff --check` passes.
- Changed only `README.md`.