### PR TITLE
Add CrossSource to 5c · RAG / retrieval evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Most "awesome" lists are link dumps. This one is **annotated and verified**: eve
 - **[RAGChecker](https://github.com/amazon-science/RAGChecker)** — Amazon Science — <https://github.com/amazon-science/RAGChecker> — 🆕 claim-level diagnosis separating retriever vs generator errors.
 - **[continuous-eval (Relari)](https://github.com/relari-ai/continuous-eval)** — <https://github.com/relari-ai/continuous-eval> — modular per-module metrics across retrieval/generation/tool-use.
 - **[Tonic Validate](https://github.com/TonicAI/tonic_validate)** — <https://github.com/TonicAI/tonic_validate> — RAG metrics as a GitHub Action for CI.
+- **[CrossSource](https://github.com/zoeb-nomi/crosssource)** — Zoeb Nomi — <https://github.com/zoeb-nomi/crosssource> — 🆕 citation-accuracy eval harness for RAG over public court opinions; validated LLM-as-judge (15/15 blind human agreement), claim-level citation precision/recall, and a prompting-vs-retrieval failure taxonomy.
 
 ### 5d · LLM-as-judge / reward / verifier libraries
 - **[verdict](https://github.com/haizelabs/verdict)** — Haize Labs — <https://github.com/haizelabs/verdict> — 🆕 declarative compound judges (debate/verification/aggregation, inference-time scaling); arXiv:2502.18018.


### PR DESCRIPTION
Adds **CrossSource** to **5c · RAG / retrieval evaluation** — an open evaluation harness measuring citation accuracy in RAG over public court opinions.

Why it clears the bar (real data + code, not a generic "you need evals" take):

- **Validated LLM-as-judge:** 15/15 blind human–judge agreement on a stratified sample.
- The validation pass itself caught a real harness bug the judge couldn't see — consecutive citations producing punctuation-only claim spans scored as citation failures. Fixing it moved citation precision **0.981 → 0.994** under strict citation discipline.
- Claim-level citation precision & recall, plus a failure taxonomy that separates prompting failures from retrieval failures.

Repo (canonical, URL verified): https://github.com/zoeb-nomi/crosssource

One addition, placed in 5c immediately after Tonic Validate; entry annotated per CONTRIBUTING.md.