### PR TITLE
Swap scan/responder model to claude-opus-4-6

### DIFF
--- a/.github/workflows/eval-scan.yml
+++ b/.github/workflows/eval-scan.yml
@@ -73,7 +73,7 @@ jobs:
           # only needs to push a branch + open a PR, which GITHUB_TOKEN + permissions above cover.
           github_token: ${{ secrets.GITHUB_TOKEN }}
           settings: ".github/claude-scan-settings.json"
-          claude_args: "--model claude-sonnet-4-6 --max-turns 200"
+          claude_args: "--model claude-opus-4-6 --max-turns 200"
           prompt: |
             You are the autonomous daily curator for **benchflow-ai/awesome-evals**. Find NEW, genuinely
             high-signal agent-evaluation content, vet it RUTHLESSLY, verify it, and open ONE review PR — or

--- a/.github/workflows/respond.yml
+++ b/.github/workflows/respond.yml
@@ -46,7 +46,7 @@ jobs:
           # 401; the bot only needs to comment, which GITHUB_TOKEN + the permissions above cover).
           github_token: ${{ secrets.GITHUB_TOKEN }}
           settings: ".github/claude-respond-settings.json"
-          claude_args: "--model claude-sonnet-4-6 --max-turns 25"
+          claude_args: "--model claude-opus-4-6 --max-turns 25"
           prompt: |
             You are the assistant for the **benchflow-ai/awesome-evals** repo — a curated, non-BS agent-evals
             list. Post exactly ONE warm, concise, technical comment. You may ONLY comment: never edit files,


### PR DESCRIPTION
Bumps the model used by both automations (eval-scan.yml, respond.yml) from claude-sonnet-4-6 to claude-opus-4-6.

Separately: the actual cause of the recent run failures (Responder on #84/#85, Eval Scan on 08-20) is unrelated to the model — the runs are failing at auth (`is_error:true`, 578ms, $0 cost) because the `CLAUDE_CODE_OAUTH_TOKEN` secret (set 2026-06-25) looks expired. That needs a secret rotation, which I can't do myself (no repo-secrets access) — see the accompanying message for the command.